### PR TITLE
Remove edition from the install script call

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ resource "google_compute_instance" "yugabyte_node" {
             "chmod +x /home/${var.ssh_user}/create_universe.sh",
             "chmod +x /home/${var.ssh_user}/start_tserver.sh",
             "chmod +x /home/${var.ssh_user}/start_master.sh",
-            "/home/${var.ssh_user}/install_software.sh '${var.yb_edition}' '${var.yb_version}' '${var.yb_download_url}'"
+            "/home/${var.ssh_user}/install_software.sh '${var.yb_version}' '${var.yb_download_url}'"
         ]
         connection {
             type = "ssh"

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,7 +2,31 @@ output "ui" {
   sensitive = false
   value     = "http://${google_compute_instance.yugabyte_node.0.network_interface.0.access_config.0.nat_ip}:7000"
 }
+output "ssh_user" {
+  sensitive = false
+  value = "${var.ssh_user}"
+}
 output "ssh_key" {
   sensitive = false
   value     = "${var.ssh_private_key}"
 }
+
+output "JDBC" {
+  sensitive =false
+  value     = "postgresql://postgres@${google_compute_instance.yugabyte_node.0.network_interface.0.access_config.0.nat_ip}:5433"
+}
+
+output "YSQL"{
+  sensitive = false
+  value     = "psql -U postgres -h ${google_compute_instance.yugabyte_node.0.network_interface.0.access_config.0.nat_ip} -p 5433"
+}
+
+output "YCQL"{
+  sensitive = false
+  value     = "cqlsh ${google_compute_instance.yugabyte_node.0.network_interface.0.access_config.0.nat_ip} 9042"
+}
+
+output "YEDIS"{
+  sensitive = false
+  value     = "redis-cli -h ${google_compute_instance.yugabyte_node.0.network_interface.0.access_config.0.nat_ip} -p 6379"
+ }


### PR DESCRIPTION
With the latest utilities module, we don't have edition flag anymore.

Tested by running

`terraform apply`