### PR TITLE
Update to previous dedup fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ locals {
     depends_on = ["google_compute_instance.yugabyte_node"]
     ssh_ip_list = "${var.use_public_ip_for_ssh == "true" ? join(" ",google_compute_instance.yugabyte_node.*.network_interface.0.access_config.0.nat_ip) : join(" ",google_compute_instance.yugabyte_node.*.network_interface.0.network_ip)}"
     config_ip_list = "${join(" ",google_compute_instance.yugabyte_node.*.network_interface.0.network_ip)}"
-    zone = "${join(" ", distinct(google_compute_instance.yugabyte_node.*.zone))}"
+    zone = "${join(" ", google_compute_instance.yugabyte_node.*.zone)}"
 }
 
 resource "null_resource" "create_yugabyte_universe" {


### PR DESCRIPTION
We still need to send over the full list of zones to create_universe.sh so that it can assign them to each node. That was an error in the previous fix.

I tested this fix with a 6 node count cluster with rf = 3.

Also merge in https://github.com/yugabyte/utilities/commit/7cd2031b7ed70e2957febb71d5a906d6baa5f333