### PR TITLE
Add triggers to null_resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,6 +116,11 @@ locals {
 }
 
 resource "null_resource" "create_yugabyte_universe" {
+  # Define the trigger condition to run the provisioner block
+  triggers = {
+    cluster_instance_ids = "${join(",", google_compute_instance.yugabyte_node.*.id)}"
+  }
+
   depends_on = [google_compute_instance.yugabyte_node]
 
   provisioner "local-exec" {


### PR DESCRIPTION
- This will run create_universe.sh whenever there is change in nodes

### Scenarios tested
- Created a stack with RF = 3 and nodes = 3
- Updated it to 7 nodes.
- New TServer nodes got added to the cluster and master nodes don't change as the new nodes are added at the end of sequence.

Ref: https://github.com/yugabyte/yugabyte-db/issues/4958